### PR TITLE
Fix Odoo order sync helpers

### DIFF
--- a/odooflow.php
+++ b/odooflow.php
@@ -2993,10 +2993,78 @@ class OdooFlow {
      * Create product in Odoo
      */
     private function create_odoo_product($product_data) {
-        // Implementation for creating product in Odoo
-        // This would use the XML-RPC API to create a product
-        // Return the Odoo product ID or WP_Error
-        return 0; // Placeholder
+        $odoo_url = get_option('odooflow_odoo_url', '');
+        $username = get_option('odooflow_username', '');
+        $api_key  = get_option('odooflow_api_key', '');
+        $database = get_option('odooflow_database', '');
+
+        if (empty($odoo_url) || empty($username) || empty($api_key) || empty($database)) {
+            return new WP_Error('missing_credentials', __('Odoo connection settings are incomplete.', 'odooflow'));
+        }
+
+        $uid = $this->authenticate_odoo($odoo_url, $database, $username, $api_key);
+        if (is_wp_error($uid)) {
+            return $uid;
+        }
+
+        $object_ep = rtrim($odoo_url, '/') . '/xmlrpc/2/object';
+
+        // Attempt to find existing product by SKU
+        $odoo_id = 0;
+        if (!empty($product_data['default_code'])) {
+            $search_req = xmlrpc_encode_request('execute_kw', [
+                $database,
+                $uid,
+                $api_key,
+                'product.template',
+                'search_read',
+                [[['default_code', '=', $product_data['default_code']]]],
+                ['fields' => ['id'], 'limit' => 1],
+            ]);
+
+            $resp = wp_remote_post($object_ep, [
+                'body'      => $search_req,
+                'headers'   => ['Content-Type' => 'text/xml'],
+                'timeout'   => 30,
+                'sslverify' => false,
+            ]);
+
+            $res = is_wp_error($resp) ? [] : xmlrpc_decode(wp_remote_retrieve_body($resp));
+            if (is_array($res) && !empty($res)) {
+                $odoo_id = (int) $res[0]['id'];
+            }
+        }
+
+        if ($odoo_id) {
+            return $odoo_id;
+        }
+
+        $create_req = xmlrpc_encode_request('execute_kw', [
+            $database,
+            $uid,
+            $api_key,
+            'product.template',
+            'create',
+            [$product_data],
+        ]);
+
+        $resp = wp_remote_post($object_ep, [
+            'body'      => $create_req,
+            'headers'   => ['Content-Type' => 'text/xml'],
+            'timeout'   => 30,
+            'sslverify' => false,
+        ]);
+
+        if (is_wp_error($resp)) {
+            return new WP_Error('create_error', __('Error creating product in Odoo.', 'odooflow'));
+        }
+
+        $res = xmlrpc_decode(wp_remote_retrieve_body($resp));
+        if (!is_numeric($res)) {
+            return new WP_Error('create_failed', __('Failed to create product in Odoo.', 'odooflow'));
+        }
+
+        return (int) $res;
     }
 
     /**
@@ -3078,10 +3146,78 @@ class OdooFlow {
      * Create customer in Odoo
      */
     private function create_odoo_customer($customer_data) {
-        // Implementation for creating customer in Odoo
-        // This would use the XML-RPC API to create a customer
-        // Return the Odoo customer ID or WP_Error
-        return 0; // Placeholder
+        $odoo_url = get_option('odooflow_odoo_url', '');
+        $username = get_option('odooflow_username', '');
+        $api_key  = get_option('odooflow_api_key', '');
+        $database = get_option('odooflow_database', '');
+
+        if (empty($odoo_url) || empty($username) || empty($api_key) || empty($database)) {
+            return new WP_Error('missing_credentials', __('Odoo connection settings are incomplete.', 'odooflow'));
+        }
+
+        $uid = $this->authenticate_odoo($odoo_url, $database, $username, $api_key);
+        if (is_wp_error($uid)) {
+            return $uid;
+        }
+
+        $object_ep = rtrim($odoo_url, '/') . '/xmlrpc/2/object';
+
+        // Attempt to locate an existing partner by email
+        $odoo_id = 0;
+        if (!empty($customer_data['email'])) {
+            $search_req = xmlrpc_encode_request('execute_kw', [
+                $database,
+                $uid,
+                $api_key,
+                'res.partner',
+                'search_read',
+                [[['email', '=', $customer_data['email']]]],
+                ['fields' => ['id'], 'limit' => 1],
+            ]);
+
+            $resp = wp_remote_post($object_ep, [
+                'body'      => $search_req,
+                'headers'   => ['Content-Type' => 'text/xml'],
+                'timeout'   => 30,
+                'sslverify' => false,
+            ]);
+
+            $res = is_wp_error($resp) ? [] : xmlrpc_decode(wp_remote_retrieve_body($resp));
+            if (is_array($res) && !empty($res)) {
+                $odoo_id = (int) $res[0]['id'];
+            }
+        }
+
+        if ($odoo_id) {
+            return $odoo_id;
+        }
+
+        $create_req = xmlrpc_encode_request('execute_kw', [
+            $database,
+            $uid,
+            $api_key,
+            'res.partner',
+            'create',
+            [$customer_data],
+        ]);
+
+        $resp = wp_remote_post($object_ep, [
+            'body'      => $create_req,
+            'headers'   => ['Content-Type' => 'text/xml'],
+            'timeout'   => 30,
+            'sslverify' => false,
+        ]);
+
+        if (is_wp_error($resp)) {
+            return new WP_Error('create_error', __('Error creating customer in Odoo.', 'odooflow'));
+        }
+
+        $res = xmlrpc_decode(wp_remote_retrieve_body($resp));
+        if (!is_numeric($res)) {
+            return new WP_Error('create_failed', __('Failed to create customer in Odoo.', 'odooflow'));
+        }
+
+        return (int) $res;
     }
 
     /**
@@ -3122,18 +3258,151 @@ class OdooFlow {
      * Get Odoo tax ID
      */
     private function get_odoo_tax_id($wc_tax_id) {
-        // Implementation to map WooCommerce tax to Odoo tax
-        // This would need to be configured in the plugin settings
-        return 0; // Placeholder
+        static $cache = [];
+        if (isset($cache[$wc_tax_id])) {
+            return $cache[$wc_tax_id];
+        }
+
+        $mapping = get_option('odooflow_tax_map', []);
+        if (is_array($mapping) && isset($mapping[$wc_tax_id])) {
+            $cache[$wc_tax_id] = (int) $mapping[$wc_tax_id];
+            return $cache[$wc_tax_id];
+        }
+
+        $rate_data = WC_Tax::get_rate($wc_tax_id);
+        if (!$rate_data) {
+            $cache[$wc_tax_id] = 0;
+            return 0;
+        }
+
+        $name = $rate_data['tax_rate_name'] ?? '';
+        $rate = isset($rate_data['tax_rate']) ? (float) $rate_data['tax_rate'] : null;
+
+        $odoo_url = get_option('odooflow_odoo_url', '');
+        $username = get_option('odooflow_username', '');
+        $api_key  = get_option('odooflow_api_key', '');
+        $database = get_option('odooflow_database', '');
+
+        if (empty($odoo_url) || empty($username) || empty($api_key) || empty($database)) {
+            $cache[$wc_tax_id] = 0;
+            return 0;
+        }
+
+        $uid = $this->authenticate_odoo($odoo_url, $database, $username, $api_key);
+        if (is_wp_error($uid)) {
+            $cache[$wc_tax_id] = 0;
+            return 0;
+        }
+
+        $object_ep = rtrim($odoo_url, '/') . '/xmlrpc/2/object';
+
+        // Search by name first
+        $search_req = xmlrpc_encode_request('execute_kw', [
+            $database,
+            $uid,
+            $api_key,
+            'account.tax',
+            'search_read',
+            [[['name', '=', $name]]],
+            ['fields' => ['id'], 'limit' => 1],
+        ]);
+        $resp = wp_remote_post($object_ep, [
+            'body'      => $search_req,
+            'headers'   => ['Content-Type' => 'text/xml'],
+            'timeout'   => 30,
+            'sslverify' => false,
+        ]);
+        $res = is_wp_error($resp) ? [] : xmlrpc_decode(wp_remote_retrieve_body($resp));
+        if (is_array($res) && !empty($res)) {
+            $cache[$wc_tax_id] = (int) $res[0]['id'];
+            return $cache[$wc_tax_id];
+        }
+
+        // Search by rate
+        if ($rate !== null) {
+            $search_req = xmlrpc_encode_request('execute_kw', [
+                $database,
+                $uid,
+                $api_key,
+                'account.tax',
+                'search_read',
+                [[['amount', '=', $rate], ['type_tax_use', '=', 'sale']]],
+                ['fields' => ['id'], 'limit' => 1],
+            ]);
+            $resp = wp_remote_post($object_ep, [
+                'body'      => $search_req,
+                'headers'   => ['Content-Type' => 'text/xml'],
+                'timeout'   => 30,
+                'sslverify' => false,
+            ]);
+            $res = is_wp_error($resp) ? [] : xmlrpc_decode(wp_remote_retrieve_body($resp));
+            if (is_array($res) && !empty($res)) {
+                $cache[$wc_tax_id] = (int) $res[0]['id'];
+                return $cache[$wc_tax_id];
+            }
+        }
+
+        $cache[$wc_tax_id] = 0;
+        return 0;
     }
 
     /**
      * Get currency ID from Odoo
      */
     private function get_currency_id($currency_code) {
-        // Implementation to get currency ID from Odoo
-        // This would need to be cached for performance
-        return 0; // Placeholder
+        static $cache = [];
+        $code = strtoupper(trim($currency_code));
+        if (isset($cache[$code]) || $code === '') {
+            return $cache[$code] ?? 0;
+        }
+
+        // WPML multi-currency integration
+        if (function_exists('wcml_get_currencies')) {
+            $currencies = wcml_get_currencies();
+            if (isset($currencies[$code]['default'])) {
+                $code = $currencies[$code]['default'];
+            }
+        }
+
+        $odoo_url = get_option('odooflow_odoo_url', '');
+        $username = get_option('odooflow_username', '');
+        $api_key  = get_option('odooflow_api_key', '');
+        $database = get_option('odooflow_database', '');
+
+        if (empty($odoo_url) || empty($username) || empty($api_key) || empty($database)) {
+            $cache[$code] = 0;
+            return 0;
+        }
+
+        $uid = $this->authenticate_odoo($odoo_url, $database, $username, $api_key);
+        if (is_wp_error($uid)) {
+            $cache[$code] = 0;
+            return 0;
+        }
+
+        $object_ep = rtrim($odoo_url, '/') . '/xmlrpc/2/object';
+        $request = xmlrpc_encode_request('execute_kw', [
+            $database,
+            $uid,
+            $api_key,
+            'res.currency',
+            'search_read',
+            [[['name', '=', $code]]],
+            ['fields' => ['id'], 'limit' => 1],
+        ]);
+
+        $response = wp_remote_post($object_ep, [
+            'body'      => $request,
+            'headers'   => ['Content-Type' => 'text/xml'],
+            'timeout'   => 30,
+            'sslverify' => false,
+        ]);
+
+        $result = is_wp_error($response) ? [] : xmlrpc_decode(wp_remote_retrieve_body($response));
+
+        $id = (is_array($result) && !empty($result)) ? (int) $result[0]['id'] : 0;
+        $cache[$code] = $id;
+        return $id;
     }
 
     /**


### PR DESCRIPTION
## Summary
- implement `create_odoo_product` to create/search product in Odoo
- implement `create_odoo_customer` to create/search customer in Odoo
- map WooCommerce taxes to Odoo via `get_odoo_tax_id`
- implement currency lookup with WPML support in `get_currency_id`

## Testing
- `composer validate --no-check-all`
- `find . -name '*.php' | xargs -I {} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_6872d72e4864833281a401dbde658722