### PR TITLE
Fix order sync to create missing customers and products

### DIFF
--- a/odooflow.php
+++ b/odooflow.php
@@ -2856,7 +2856,7 @@ class OdooFlow {
 
         // Prepare order lines
         error_log('OdooFlow: Preparing order lines');
-        $order_lines = $this->prepare_order_lines($order);
+        $order_lines = $this->prepare_order_lines($order, $database, $uid, $api_key);
         error_log('OdooFlow: Order lines prepared: ' . print_r($order_lines, true));
         
         $order_data = array(
@@ -2925,11 +2925,16 @@ class OdooFlow {
     /**
      * Prepare order line items for Odoo
      */
-    private function prepare_order_lines($order) {
+    private function prepare_order_lines($order, $database, $uid, $api_key) {
         $lines = array();
         
         foreach ($order->get_items() as $item) {
-            $product_id = $this->get_or_create_odoo_product($item->get_product());
+            $product_id = $this->get_or_create_odoo_product(
+                $item->get_product(),
+                $database,
+                $uid,
+                $api_key
+            );
             if (!$product_id) continue;
 
             $line = array(
@@ -2964,23 +2969,59 @@ class OdooFlow {
     /**
      * Get or create Odoo product
      */
-    private function get_or_create_odoo_product($product) {
-        if (!$product) return false;
+    private function get_or_create_odoo_product($product, $database, $uid, $api_key) {
+        if (!$product) {
+            return false;
+        }
 
         $odoo_product_id = get_post_meta($product->get_id(), '_odoo_product_id', true);
-        if ($odoo_product_id) return $odoo_product_id;
+        if ($odoo_product_id) {
+            return $odoo_product_id;
+        }
 
-        // Create product in Odoo if it doesn't exist
+        $object_endpoint = rtrim(get_option('odooflow_odoo_url', ''), '/') . '/xmlrpc/2/object';
+
+        // Search product in Odoo by SKU
+        $sku = $product->get_sku();
+        if ($sku) {
+            $search_request = xmlrpc_encode_request('execute_kw', array(
+                $database,
+                $uid,
+                $api_key,
+                'product.template',
+                'search_read',
+                array(array(array('default_code', '=', $sku))),
+                array('fields' => array('id'), 'limit' => 1)
+            ));
+
+            $search_response = wp_remote_post($object_endpoint, array(
+                'body'      => $search_request,
+                'headers'   => array('Content-Type' => 'text/xml'),
+                'timeout'   => 30,
+                'sslverify' => false
+            ));
+
+            $search_result = is_wp_error($search_response)
+                ? array()
+                : xmlrpc_decode(wp_remote_retrieve_body($search_response));
+
+            if (is_array($search_result) && !empty($search_result)) {
+                $found_id = (int) $search_result[0]['id'];
+                update_post_meta($product->get_id(), '_odoo_product_id', $found_id);
+                return $found_id;
+            }
+        }
+
+        // Product not found, create it
         $product_data = array(
-            'name' => $product->get_name(),
-            'default_code' => $product->get_sku(),
-            'list_price' => $product->get_regular_price(),
-            'type' => 'product',
-            'sale_ok' => true
+            'name'         => $product->get_name(),
+            'default_code' => $sku,
+            'list_price'   => $product->get_regular_price(),
+            'type'         => 'product',
+            'sale_ok'      => true
         );
 
-        // Create product in Odoo
-        $result = $this->create_odoo_product($product_data);
+        $result = $this->create_odoo_product($product_data, $database, $uid, $api_key);
         if (!is_wp_error($result)) {
             update_post_meta($product->get_id(), '_odoo_product_id', $result);
             return $result;
@@ -2992,11 +3033,40 @@ class OdooFlow {
     /**
      * Create product in Odoo
      */
-    private function create_odoo_product($product_data) {
-        // Implementation for creating product in Odoo
-        // This would use the XML-RPC API to create a product
-        // Return the Odoo product ID or WP_Error
-        return 0; // Placeholder
+    private function create_odoo_product($product_data, $database, $uid, $api_key) {
+        $odoo_url = get_option('odooflow_odoo_url', '');
+        if (empty($odoo_url)) {
+            return new WP_Error('missing_url', __('Odoo URL not configured', 'odooflow'));
+        }
+
+        $object_endpoint = rtrim($odoo_url, '/') . '/xmlrpc/2/object';
+
+        $request = xmlrpc_encode_request('execute_kw', array(
+            $database,
+            $uid,
+            $api_key,
+            'product.template',
+            'create',
+            array($product_data)
+        ));
+
+        $response = wp_remote_post($object_endpoint, array(
+            'body'      => $request,
+            'headers'   => array('Content-Type' => 'text/xml'),
+            'timeout'   => 30,
+            'sslverify' => false
+        ));
+
+        if (is_wp_error($response)) {
+            return new WP_Error('create_error', $response->get_error_message());
+        }
+
+        $result = xmlrpc_decode(wp_remote_retrieve_body($response));
+        if (!is_numeric($result)) {
+            return new WP_Error('create_failed', __('Failed to create product in Odoo', 'odooflow'));
+        }
+
+        return (int) $result;
     }
 
     /**
@@ -3006,10 +3076,45 @@ class OdooFlow {
         $customer_id = $order->get_customer_id();
         if ($customer_id) {
             $odoo_customer_id = get_user_meta($customer_id, '_odoo_customer_id', true);
-            if ($odoo_customer_id) return $odoo_customer_id;
+            if ($odoo_customer_id) {
+                return $odoo_customer_id;
+            }
         }
 
         $object_endpoint = rtrim(get_option('odooflow_odoo_url', ''), '/') . '/xmlrpc/2/object';
+
+        // Search for customer by email in Odoo
+        $email = $order->get_billing_email();
+        if ($email) {
+            $search_request = xmlrpc_encode_request('execute_kw', array(
+                $database,
+                $uid,
+                $api_key,
+                'res.partner',
+                'search_read',
+                array(array(array('email', '=', $email))),
+                array('fields' => array('id'), 'limit' => 1)
+            ));
+
+            $search_response = wp_remote_post($object_endpoint, array(
+                'body'      => $search_request,
+                'headers'   => array('Content-Type' => 'text/xml'),
+                'timeout'   => 30,
+                'sslverify' => false
+            ));
+
+            $search_result = is_wp_error($search_response)
+                ? array()
+                : xmlrpc_decode(wp_remote_retrieve_body($search_response));
+
+            if (is_array($search_result) && !empty($search_result)) {
+                $found_id = (int) $search_result[0]['id'];
+                if ($customer_id) {
+                    update_user_meta($customer_id, '_odoo_customer_id', $found_id);
+                }
+                return $found_id;
+            }
+        }
 
         // Prepare geographical information
         $country_id = $this->get_country_id(
@@ -3058,7 +3163,7 @@ class OdooFlow {
         );
 
         // Create customer in Odoo
-        $result = $this->create_odoo_customer($customer_data);
+        $result = $this->create_odoo_customer($customer_data, $database, $uid, $api_key);
         if (!is_wp_error($result) && $customer_id) {
             update_user_meta($customer_id, '_odoo_customer_id', $result);
             $tipo_val = $order->get_meta('tipo_identificacion');
@@ -3077,11 +3182,40 @@ class OdooFlow {
     /**
      * Create customer in Odoo
      */
-    private function create_odoo_customer($customer_data) {
-        // Implementation for creating customer in Odoo
-        // This would use the XML-RPC API to create a customer
-        // Return the Odoo customer ID or WP_Error
-        return 0; // Placeholder
+    private function create_odoo_customer($customer_data, $database, $uid, $api_key) {
+        $odoo_url = get_option('odooflow_odoo_url', '');
+        if (empty($odoo_url)) {
+            return new WP_Error('missing_url', __('Odoo URL not configured', 'odooflow'));
+        }
+
+        $object_endpoint = rtrim($odoo_url, '/') . '/xmlrpc/2/object';
+
+        $request = xmlrpc_encode_request('execute_kw', array(
+            $database,
+            $uid,
+            $api_key,
+            'res.partner',
+            'create',
+            array($customer_data)
+        ));
+
+        $response = wp_remote_post($object_endpoint, array(
+            'body'      => $request,
+            'headers'   => array('Content-Type' => 'text/xml'),
+            'timeout'   => 30,
+            'sslverify' => false
+        ));
+
+        if (is_wp_error($response)) {
+            return new WP_Error('create_error', $response->get_error_message());
+        }
+
+        $result = xmlrpc_decode(wp_remote_retrieve_body($response));
+        if (!is_numeric($result)) {
+            return new WP_Error('create_failed', __('Failed to create customer in Odoo', 'odooflow'));
+        }
+
+        return (int) $result;
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure `prepare_order_lines` passes connection parameters
- look up or create products before adding order lines
- search by email when resolving customers
- create new customers and products in Odoo via XML‑RPC

## Testing
- `php -l odooflow.php`
- `composer validate --no-check-all`

------
https://chatgpt.com/codex/tasks/task_e_6872f0d5da548332886a7f289454175b