### PR TITLE
Add paginated WooCommerce product export

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -634,4 +634,10 @@
 
 .radio-label input[type="radio"] {
     margin: 0;
-} 
+}
+
+/* Load more button for WooCommerce products */
+.woo-load-more-container {
+    text-align: center;
+    margin-top: 10px;
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,4 +1,7 @@
 jQuery(document).ready(function($) {
+    let wooCurrentPage = 1;
+    let wooHasMore = false;
+    let wooSelectedFields = [];
     // Handle manual database input toggle
     $('#manual_db').on('change', function() {
         const $wrapper = $('.database-select-container');
@@ -313,15 +316,15 @@ jQuery(document).ready(function($) {
         const loadingOverlay = $('<div class="loading-overlay"><div class="loading-spinner"></div></div>');
         wooProductsList.append(loadingOverlay);
         exportModal.show();
-        
-        // Get selected fields
-        const selectedFields = getSelectedExportFields();
-        
-        // Debug log the request data
+
+        wooCurrentPage = 1;
+        wooSelectedFields = getSelectedExportFields();
+
         const requestData = {
             action: 'get_woo_products',
             nonce: odooflow.nonce,
-            fields: selectedFields
+            fields: wooSelectedFields,
+            page: wooCurrentPage
         };
         console.log('Sending request with data:', requestData);
         
@@ -333,6 +336,9 @@ jQuery(document).ready(function($) {
                 console.log('Response:', response);
                 if (response.success) {
                     wooProductsList.html(response.data.html);
+                    wooHasMore = response.data.has_more;
+                    addWooLoadMore();
+                    toggleWooLoadMore();
                 } else {
                     const errorMessage = response.data ? response.data.message : 'Unknown error occurred';
                     wooProductsList.html('<div class="notice notice-error"><p>' + errorMessage + '</p></div>');
@@ -375,6 +381,9 @@ jQuery(document).ready(function($) {
     // Export modal close handler
     $('#odoo-export-modal .odoo-modal-close').on('click', function() {
         $('#odoo-export-modal').hide();
+        wooCurrentPage = 1;
+        wooHasMore = false;
+        toggleWooLoadMore();
     });
 
     // Export field selection handlers
@@ -399,6 +408,57 @@ jQuery(document).ready(function($) {
     $('.deselect-all-woo-products').on('click', function() {
         $('input[name="export_products[]"]').prop('checked', false);
         $('#select-all-woo-products').prop('checked', false);
+    });
+
+    function addWooLoadMore() {
+        if ($('.woo-load-more-container').length === 0) {
+            $('.woo-products-list').after('<div class="woo-load-more-container" style="text-align:center;margin-top:10px;"><button type="button" class="button load-more-woo-products">Load More</button></div>');
+        }
+    }
+
+    function toggleWooLoadMore() {
+        if (wooHasMore) {
+            $('.woo-load-more-container').show();
+        } else {
+            $('.woo-load-more-container').hide();
+        }
+    }
+
+    $(document).on('click', '.load-more-woo-products', function() {
+        const $button = $(this);
+        $button.prop('disabled', true);
+        const spinner = $('<span class="spinner is-active" style="float:none;margin-left:5px;"></span>');
+        $button.after(spinner);
+
+        const requestData = {
+            action: 'get_woo_products',
+            nonce: odooflow.nonce,
+            fields: wooSelectedFields,
+            page: wooCurrentPage + 1
+        };
+
+        $.ajax({
+            url: odooflow.ajax_url,
+            type: 'POST',
+            data: requestData,
+            success: function(response) {
+                if (response.success) {
+                    wooCurrentPage += 1;
+                    $('.woo-products-list table tbody').append(response.data.html);
+                    wooHasMore = response.data.has_more;
+                    toggleWooLoadMore();
+                } else {
+                    alert(response.data ? response.data.message : 'Unknown error');
+                }
+            },
+            error: function() {
+                alert('Error loading more products.');
+            },
+            complete: function() {
+                spinner.remove();
+                $button.prop('disabled', false);
+            }
+        });
     });
     
     // Export selected products

--- a/odooflow.php
+++ b/odooflow.php
@@ -1734,11 +1734,15 @@ class OdooFlow {
             return;
         }
 
+        $page     = isset($_POST['page']) ? max(1, intval($_POST['page'])) : 1;
+        $per_page = 50;
+
         // Query WooCommerce products
         $args = array(
-            'post_type' => 'product',
-            'post_status' => 'publish',
-            'posts_per_page' => 100,
+            'post_type'      => 'product',
+            'post_status'    => 'publish',
+            'posts_per_page' => $per_page,
+            'paged'          => $page,
         );
 
         $products_query = new WP_Query($args);
@@ -1777,19 +1781,13 @@ class OdooFlow {
         }
 
         // Build the HTML for the products list
-        $html = '<table class="wp-list-table widefat fixed striped products-list">';
-        $html .= '<thead><tr>';
-        $html .= '<th class="check-column"><input type="checkbox" id="select-all-woo-products"><label for="select-all-woo-products"></label></th>';
-        $html .= '<th>' . __('Product Name', 'odooflow') . '</th>';
-        $html .= '<th>' . __('SKU', 'odooflow') . '</th>';
-        $html .= '<th>' . __('Price', 'odooflow') . '</th>';
-        $html .= '</tr></thead><tbody>';
+        $rows = '';
 
         if (empty($products)) {
-            $html .= '<tr><td colspan="4">' . __('No products found.', 'odooflow') . '</td></tr>';
+            $rows .= '<tr><td colspan="4">' . __('No products found.', 'odooflow') . '</td></tr>';
         } else {
             foreach ($products as $product) {
-                $html .= sprintf(
+                $rows .= sprintf(
                     '<tr data-product-type="%5$s">
                         <td class="check-column">
                             <input type="checkbox" name="export_products[]" id="product-%1$s" value="%1$s">
@@ -1808,10 +1806,24 @@ class OdooFlow {
             }
         }
 
-        $html .= '</tbody></table>';
+        $has_more = ($page < $products_query->max_num_pages);
+
+        if ($page === 1) {
+            $html  = '<table class="wp-list-table widefat fixed striped products-list">';
+            $html .= '<thead><tr>';
+            $html .= '<th class="check-column"><input type="checkbox" id="select-all-woo-products"><label for="select-all-woo-products"></label></th>';
+            $html .= '<th>' . __('Product Name', 'odooflow') . '</th>';
+            $html .= '<th>' . __('SKU', 'odooflow') . '</th>';
+            $html .= '<th>' . __('Price', 'odooflow') . '</th>';
+            $html .= '</tr></thead><tbody>';
+            $html .= $rows;
+            $html .= '</tbody></table>';
+        } else {
+            $html = $rows;
+        }
 
         error_log('Sending response with HTML table');
-        wp_send_json_success(array('html' => $html));
+        wp_send_json_success(array('html' => $html, 'has_more' => $has_more));
     }
 
     /**


### PR DESCRIPTION
## Summary
- enable pagination in `ajax_get_woo_products`
- add JS logic for loading additional pages of products
- show a "Load More" button when more products are available
- style the load‑more container

## Testing
- `composer validate --no-check-all --strict`

------
https://chatgpt.com/codex/tasks/task_e_6875a8c0770c8332a91cd4e83de7eea5